### PR TITLE
Replace PR template by note to add Jira ticket reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,3 @@
-## Change description
 
-> Description here
 
-## Type of change
-- [ ] Bug fix (fixes an issue)
-- [ ] New feature (adds functionality)
-
-## Related issues
-
-> Fix [#1]() 
-
-## Checklists
-
-### Development
-
-- [ ] Lint rules pass locally
-- [ ] Application changes have been tested thoroughly
-- [ ] Automated tests covering modified code pass
-
-### Security
-
-- [ ] Security impact of change has been considered
-- [ ] Code follows company security practices and guidelines
-
-### Code review 
-
-- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
-- [ ] "Ready for review" label attached and reviewers assigned
-- [ ] Changes have been reviewed by at least one other contributor
-- [ ] Pull request linked to task tracker where applicable
+<!-- Please add a reference to the Jira ticket at the end -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
 
 
-<!-- Please add a reference to the Jira ticket at the end -->
+<!--
+  Please add a reference to the Jira ticket in the description of the PR.
+  Don't forget to refer the ticket number in the PR title in the form of "TICKET-123 My PR short description" so it is also visible in the Jira ticket details. You can put "NONE My PR short description" if there is no corresponding ticket.
+  Feel free to delete this Markdown comment or leave it be. It is not going to be visible when you are done creating the PR.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,6 @@
 
 <!--
   Please add a reference to the Jira ticket in the description of the PR.
-  Don't forget to refer the ticket number in the PR title in the form of "TICKET-123 My PR short description" so it is also visible in the Jira ticket details. You can put "NONE My PR short description" if there is no corresponding ticket.
+  Don't forget to refer the ticket number in the PR title in the form of "TICKET-123 My PR short description" so it is also visible in the Jira ticket details. You can omit a ticket number if there is no corresponding ticket.
   Feel free to delete this Markdown comment or leave it be. It is not going to be visible when you are done creating the PR.
 -->


### PR DESCRIPTION
Nobody seems to use the template and just leaves it either unfilled in PR's descriptions or replaces it by something else.

Especially the first case is not great as it results in a lot of useless noise on PRs. I stopped reading anything if I see the template being used, if someone suddenly puts something important in there, I probably won't notice it.

I instead replaced the template by a simple Markdown/HTML comment, reminding developers of putting a ticket reference inside the ticket.
